### PR TITLE
🐛 Raise TypeError for mismatching validation types & Python 3.12 support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.11"]
+        python-version: ["3.12"]
 
     steps:
       - uses: actions/checkout@v4
@@ -34,6 +34,6 @@ jobs:
       - run: nox -s lint
       - run: nox -s build
       - uses: codecov/codecov-action@v2
-        if: matrix.python-version == '3.11'
+        if: matrix.python-version == '3.12'
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,4 @@ docs/lamin_logger.*
 lamin_sphinx
 docs/conf.py
 _docs_tmp*
+test.ipynb

--- a/.gitignore
+++ b/.gitignore
@@ -107,3 +107,4 @@ lamin_sphinx
 docs/conf.py
 _docs_tmp*
 test.ipynb
+test-bug

--- a/lamin_utils/_inspect.py
+++ b/lamin_utils/_inspect.py
@@ -133,9 +133,13 @@ def validate(
 
     identifiers = list(identifiers)
     identifiers_idx = pd.Index(identifiers)
-    identifiers_idx = to_str(identifiers_idx, case_sensitive=case_sensitive)
+    identifiers_idx = to_str(
+        identifiers_idx, case_sensitive=case_sensitive, series_type="identifiers"
+    )
 
-    field_values = to_str(field_values, case_sensitive=case_sensitive)
+    field_values = to_str(
+        field_values, case_sensitive=case_sensitive, series_type="field values"
+    )
 
     # annotated what complies with the default ID
     matches = identifiers_idx.isin(field_values)
@@ -236,6 +240,7 @@ def inspect(
     """Inspect if a list of identifiers are mappable to the entity reference.
 
     Args:
+        df: DataFrame containing the identifiers.
         identifiers: Identifiers that will be checked against the field.
         field: The BiontyField of the ontology to compare against.
                 Examples are 'ontology_id' to map against the source ID

--- a/lamin_utils/_inspect.py
+++ b/lamin_utils/_inspect.py
@@ -240,7 +240,7 @@ def inspect(
     """Inspect if a list of identifiers are mappable to the entity reference.
 
     Args:
-        df: DataFrame containing the identifiers.
+        df: DataFrame containing the field.
         identifiers: Identifiers that will be checked against the field.
         field: The BiontyField of the ontology to compare against.
                 Examples are 'ontology_id' to map against the source ID

--- a/lamin_utils/_map_synonyms.py
+++ b/lamin_utils/_map_synonyms.py
@@ -160,29 +160,6 @@ def to_str(
     Raises:
         ValueError: If input contains numeric data types.
     """
-    import pandas as pd
-
-    series_type_msg = f" in {series_type}" if series_type else ""
-
-    if isinstance(series_values, pd.CategoricalDtype):
-        categories = series_values.cat.categories
-        if pd.api.types.is_numeric_dtype(categories.dtype):
-            raise ValueError(
-                f"Numeric values found in categorical data{series_type_msg}. Only string/object data types are supported."
-            )
-    else:
-        if pd.api.types.is_numeric_dtype(series_values):
-            raise ValueError(
-                f"Numeric data type ({series_values.dtype}) detected{series_type_msg}. Only string/object data types are supported."
-            )
-
-        if pd.api.types.is_object_dtype(series_values):
-            numeric_mask = pd.to_numeric(series_values, errors="coerce").notna()
-            if numeric_mask.any():
-                raise ValueError(
-                    f"Numeric values found in object/string data{series_type_msg}. Only string values are supported."
-                )
-
     if series_values.dtype.name == "category":
         try:
             categorical = series_values.cat

--- a/lamin_utils/_map_synonyms.py
+++ b/lamin_utils/_map_synonyms.py
@@ -145,8 +145,6 @@ def map_synonyms(
 def to_str(
     series_values: pd.Series | pd.Index | pd.Categorical,
     case_sensitive: bool = False,
-    *,
-    series_type: Literal["identifiers", "field values"] = None,
 ) -> pd.Series:
     """Convert Pandas Series values to strings with case sensitive option.
 

--- a/lamin_utils/_map_synonyms.py
+++ b/lamin_utils/_map_synonyms.py
@@ -146,18 +146,7 @@ def to_str(
     series_values: pd.Series | pd.Index | pd.Categorical,
     case_sensitive: bool = False,
 ) -> pd.Series:
-    """Convert Pandas Series values to strings with case sensitive option.
-
-    Args:
-        identifiers: Input data to cast to str if not numeric.
-        case_sensitive: Whether to preserve string case.
-
-    Returns:
-        pd.Series: Series with string values.
-
-    Raises:
-        ValueError: If input contains numeric data types.
-    """
+    """Convert Pandas Series values to strings with case sensitive option."""
     if series_values.dtype.name == "category":
         try:
             categorical = series_values.cat

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
 ]
 dependencies = [
 ]
@@ -139,4 +140,7 @@ convention = "google"
 [tool.pytest.ini_options]
 testpaths = [
     "tests",
+]
+filterwarnings = [
+    "ignore:Jupyter is migrating its paths to use standard platformdirs:DeprecationWarning"
 ]

--- a/tests/test_inspect.py
+++ b/tests/test_inspect.py
@@ -181,6 +181,13 @@ def test_inspect_casing(genes):
     assert result.non_validated == ["a1cf"]
 
 
+@pytest.mark.parametrize("numbers", [[0, 1, 2], [0.0, 0.1, 0.2]])
+def test_inspect_numbers(numbers):
+    df = pd.DataFrame(data={"number_col": [str(val) for val in numbers]})
+    with pytest.raises(ValueError, match="Numeric values found *"):
+        _ = inspect(df=df, identifiers={"numbers": numbers}, field="number_col")
+
+
 def test_validate(genes):
     df, _ = genes
     assert validate(

--- a/tests/test_inspect.py
+++ b/tests/test_inspect.py
@@ -181,11 +181,17 @@ def test_inspect_casing(genes):
     assert result.non_validated == ["a1cf"]
 
 
-@pytest.mark.parametrize("numbers", [[0, 1, 2], [0.0, 0.1, 0.2]])
-def test_inspect_numbers(numbers):
-    df = pd.DataFrame(data={"number_col": [str(val) for val in numbers]})
-    with pytest.raises(ValueError, match="Numeric values found *"):
-        _ = inspect(df=df, identifiers={"numbers": numbers}, field="number_col")
+@pytest.mark.parametrize(
+    "identifiers, field_values",
+    [
+        ([0, 1, 2], ["a", "b", "c"]),
+        ([0.0, 0.1, 0.2], [str(val) for val in [0.0, 0.1, 0.2]]),
+    ],
+)
+def test_type_compatibility_raises_with_df(identifiers, field_values):
+    df = pd.DataFrame({"field_col": field_values})
+    with pytest.raises(TypeError, match="Type mismatch"):
+        _ = inspect(df=df, identifiers=pd.Series(identifiers), field="field_col")
 
 
 def test_validate(genes):


### PR DESCRIPTION
Related to https://github.com/laminlabs/lamindb/issues/2124

- Adds Python 3.12 support
- Now raises a `TypeError` if the `identifiers` and `field_values` have different high level types (numbers and strings/categoricals)

Note that this does NOT fix 2124 because the range index gets transformed to a str index.