### PR TITLE
✨ Use Richhandler for logging with Rich

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
 ]
 dependencies = [
+    "rich"
 ]
 
 [project.urls]


### PR DESCRIPTION
A bit of late night claude wrangling.

- Now using https://rich.readthedocs.io/en/stable/logging.html to render colors. The issue is that it kind of enforces a `console` object where text output is no longer raw. Therefore, the messages look a bit different and "dark" in vscode. I could not find an easy way to get rid of the Console object. There might be a way to not use `Richhandler` and use raw Rich `print` instead to circumvent the console object.
![image](https://github.com/user-attachments/assets/cc39a35d-7f78-4de0-8db7-7c10ceba8861)
![image](https://github.com/user-attachments/assets/5aa060eb-e46f-42ed-8a34-05a23e3cbf5c)
![image](https://github.com/user-attachments/assets/0a6b08ee-6db1-4f7a-8744-3a27601bce0c)
- Adds Rich as a dependency
- Is not properly tested yet. Consider this a MVP and potentially use it as inspiration.

