### PR TITLE
🐛 Escape search string before passing to regex to rank

### DIFF
--- a/lamin_utils/_search.py
+++ b/lamin_utils/_search.py
@@ -17,8 +17,7 @@ def _contains(col: Series, string: str, case_sensitive: bool, fields_convert: di
 
 
 # apply ranking based on rules
-# `string` - escaped search query, the argument is just for caching,
-# to avoid recompute of escaping on every call
+# `string` - escaped search query,
 def _ranks(
     col: Series,
     string: str,

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -110,7 +110,7 @@ def test_search_empty_df():
     assert res.shape == (0, 3)
 
 
-def test_escape_string():
+def test_escape_string(df):
     res = search(df=df, string="cat[")
     assert len(res) == 1
     assert res.iloc[0]["name"] == "cat[*_*]"

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -34,6 +34,13 @@ def df():
             "description": "A Specialized Cardiac Myocyte In The Sinoatrial And Atrioventricular Nodes. The Cell Is Slender And Fusiform Confined To The Nodal Center, Circumferentially Arranged Around The Nodal Artery.",
             "children": ["CL:1000409", "CL:1000410"],
         },
+        {
+            "ontology_id": "",
+            "name": "cat[*_*]",
+            "synonyms": "",
+            "description": "",
+            "children": [],
+        },
     ]
     return pd.DataFrame.from_records(records)
 
@@ -101,3 +108,13 @@ def test_search_case_sensitive(df):
 def test_search_empty_df():
     res = search(pd.DataFrame(columns=["a", "b", "c"]), string="")
     assert res.shape == (0, 3)
+
+
+def test_escape_string():
+    res = search(df=df, string="cat[")
+    assert len(res) == 1
+    assert res.iloc[0]["name"] == "cat[*_*]"
+
+    res = search(df=df, string="*_*")
+    assert len(res) == 1
+    assert res.iloc[0]["name"] == "cat[*_*]"


### PR DESCRIPTION
related https://github.com/laminlabs/lamindb/pull/2261 https://github.com/laminlabs/laminhub/pull/1710
Less important than for the hub or `lamindb` but should be the same for consistency.